### PR TITLE
feature(http-filter): Add filter for http exceptions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,8 +4,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { join } from 'path';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { APP_INTERCEPTOR } from '@nestjs/core';
-import { HttpLoggingInterceptor } from './shared/interceptor/http-logging.interceptor';
 
 @Module({
   imports: [TypeOrmModule.forRoot({

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { join } from 'path';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './shared/filter/http-exception.filter';
 import { HttpLoggingInterceptor } from './shared/interceptor/http-logging.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalInterceptors(new HttpLoggingInterceptor());
 
   await app.listen(3000);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './shared/filter/http-exception.filter';

--- a/src/shared/filter/http-exception.filter.ts
+++ b/src/shared/filter/http-exception.filter.ts
@@ -1,6 +1,6 @@
 import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Logger } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { IHttpError } from '../interface/http-error.interface';
+import { IHttpException } from '../interface/http-exception.interface';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
@@ -11,7 +11,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const response = httpContext.getResponse<Response>();
     const status = exception.getStatus();
 
-    const errorResponse: IHttpError = {
+    const errorResponse: IHttpException = {
       code: status,
       message: exception.message || null,
       timestamp: new Date().toLocaleDateString(),

--- a/src/shared/filter/http-exception.filter.ts
+++ b/src/shared/filter/http-exception.filter.ts
@@ -1,0 +1,28 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Logger } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { IHttpError } from '../interface/http-error.interface';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const httpContext = host.switchToHttp();
+    const request = httpContext.getRequest<Request>();
+    const response = httpContext.getResponse<Response>();
+    const status = exception.getStatus();
+
+    const errorResponse: IHttpError = {
+      code: status,
+      message: exception.message || null,
+      timestamp: new Date().toLocaleDateString(),
+      path: request.url,
+      method: request.method
+    };
+
+    Logger.error(`${request.method} ${request.url}`, JSON.stringify(errorResponse), 'HttpExceptionFilter');
+
+    response
+      .status(status)
+      .json(errorResponse);      
+  }
+}

--- a/src/shared/interface/http-error.interface.ts
+++ b/src/shared/interface/http-error.interface.ts
@@ -1,0 +1,11 @@
+export interface IHttpError {
+  code: number;
+
+  message: string;
+
+  timestamp: Date | string;
+
+  method: string;
+
+  path: string;
+}

--- a/src/shared/interface/http-exception.interface.ts
+++ b/src/shared/interface/http-exception.interface.ts
@@ -1,4 +1,4 @@
-export interface IHttpError {
+export interface IHttpException {
   code: number;
 
   message: string;


### PR DESCRIPTION
If applied, this pull request will:
- Add an Http Exception Filter that will catch every HttpException that was thrown in the application;
- Register the Http Exception Filter globally;
- Log the Http Exception when it occurs;
- Add an interface for the response that the application will send back to the client when the Http Exception occurs;
- Fix the dotenv configuration location;
- Remove unused imports.